### PR TITLE
Add configuration files

### DIFF
--- a/data/homepage.yml
+++ b/data/homepage.yml
@@ -1,0 +1,124 @@
+## Looking for strings? Check the i18n folder.
+
+# showcase
+showcase:
+  enable: true
+  image:
+    x: "images/showcase/showcase.png"
+    _2x: "images/showcase/showcase@2x.png"
+  imageMobile:
+    x: "images/showcase/showcase-mobile.jpg"
+
+  button:
+    icon: "icon-email"
+    URL: "https://www.adrianmoreno.info/"
+
+  socialLinks:
+    - icon: "linkedin"
+      URL: "https://www.linkedin.com/in/adrianmoreno/"
+
+    - icon: "square-github"
+      URL: "https://github.com/zetxek"
+
+    - icon: "x-twitter"
+      URL: "https://twitter.com/zetxek"
+
+    - icon: "dribbble"
+      URL: "#"
+
+    - icon: "behance"
+      URL: "#"
+
+    - icon: "youtube"
+      URL: "#"
+
+    - icon: "instagram"
+      URL: "https://www.instagram.com/zetxek/"
+
+    - icon: "square-facebook"
+      URL: "https://www.facebook.com/zetxek/"
+
+    - icon: "codepen"
+      URL: "#"
+
+    - icon: "yelp"
+      URL: "https://www.yelp.com/"
+
+    - icon: "bluesky"
+      URL: "https://www.bluesky.com/"
+
+    - icon: "threads"
+      URL: "https://www.threads.net/"
+
+    - icon: "face-smile"
+      URL: "https://www.adrianmoreno.info/"
+
+    - icon: "user"
+      URL: "https://www.adrianmoreno.info/"
+
+    - icon: "quote-left"
+      URL: "https://www.adrianmoreno.info/"
+
+    - icon: "cloud-arrow-down"
+      URL: "https://www.adrianmoreno.info/"
+# about
+about:
+  enable: true
+  button:
+    icon: "icon-user"
+    URL: "https://www.linkedin.com/in/adrianmoreno/"
+  image:
+    x: "images/about/user-picture.png"
+    _2x: "images/about/user-picture@2x.png"
+
+# education
+education:
+  enable: true
+  items:
+    - university: "University of Life"
+      year: "2012-2017"
+      degree: "Bachelor of Applied Science (BASc), Electrical Engineering"
+
+    - university: "High School of Hard Knocks"
+      year: "2009-2012"
+      degree: "High School Diploma, Sciences, Math, Computer & Business Studies"
+
+# experience
+## to hiden a button, set the icon to an empty string
+experience:
+  enable: true
+  button:
+    enable: true
+    icon: "icon-linkedin"
+    ## the url and text are localized, fill them in the i18n file
+    ## keys: experience_button, experience_button_url
+  button2:
+    enable: true
+    icon: "icon-file-pdf"
+    ## the url and text are localized, fill them in the i18n file
+    ## keys: experience_button2, experience_button_url2 
+  button3:
+    enable: true
+    icon: "icon-cloud-arrow-down"
+    ## the url and text are localized, fill them in the i18n file
+    ## keys: experience_button2, experience_button_url2 
+
+# Client & Work
+client_and_work:
+  enable: true
+
+# testimonial
+testimonial:
+  enable: true
+
+# contact
+contact:
+  enable: true
+  form:
+    action: "#"
+  button:
+    icon: "icon-email"
+
+# newsletter
+newsletter:
+  enable: true

--- a/hugo.toml
+++ b/hugo.toml
@@ -2,6 +2,239 @@ baseURL = 'https://example.org/'
 languageCode = 'en-us'
 title = 'My New Hugo Site'
 
+
 [module]
-  [[module.imports]]
-    path = "github.com/zetxek/adritian-free-hugo-theme"
+[module.hugoVersion]
+# We use hugo.Deps to list dependencies, which was added in Hugo 0.92.0
+min = "0.92.0"
+
+[[module.imports]]
+path="github.com/zetxek/adritian-free-hugo-theme"
+
+[params]
+
+  title = 'Adritian - a high performance hugo theme by Adrián Moreno'
+  description = 'This hugo theme (Adritian) is based on Bootstrap and has features that make it suitable for a personal site, a portfolio or other kind of Single Page Applications.'
+  images = ['/img/og-img.png']
+  sections = ["showcase", "about", "education", "experience", "client-and-work", "testimonial", "contact", "newsletter"]
+
+  homepageExperienceCount = 6
+
+  [params.analytics]
+  ## Analytics parameters.
+  ### Supported so far: Vercel (Page Insights, Analytics)
+  ### And Google (Tag Manager, Analytics)
+
+  # controls vercel page insights - disabled by default
+  # to enable, just set to true
+  vercelPageInsights = false
+  vercelAnalytics = false
+  
+  # google analytics and tag manager. to enable, set "enabled" to true
+  # and add the tracking code (UA-something for analytics, GTM-something for tag manager)
+  [params.analytics.googleAnalytics]
+      code = "UA-XXXXX-Y"
+      enabled = false
+  [params.analytics.googleTagManager]
+      code = "GTM-XXXXX"
+      enabled = false
+
+[build]
+  [build.buildStats]
+    disableClasses = false
+    disableIDs = false
+    disableTags = false
+    enable = true
+
+[params.languages.selector.disable]
+  footer = false
+
+[languages]
+  [languages.en]
+    disabled = false
+    languageCode = 'en'
+    languageDirection = 'ltr'
+    languageName = 'English'
+    title = ''
+    weight = 0
+
+    [languages.en.menus]
+      [[languages.en.menus.header]]
+        name = 'About'
+        URL = '#about'
+        weight = 2
+      [[languages.en.menus.header]]
+        name = 'Portfolio'
+        URL = '#portfolio'
+        weight = 3
+      #  [[languages.en.menus.header]]
+      #  name = "Experience"
+      #  URL = "#experience"
+      #  weight = 4
+
+      [[languages.en.menus.header]]
+        name = "Blog"
+        URL = "/blog"
+        weight = 5
+
+      [[languages.en.menus.header]]
+        name = "Contact"
+        URL = "#contact"
+        weight = 6
+
+      [[languages.en.menus.footer]]
+        name = "About"
+        URL = "#about"
+        weight = 2
+
+      [[languages.en.menus.footer]]
+        name = "Portfolio"
+        URL = "#portfolio"
+        weight = 3
+
+      [[languages.en.menus.footer]]
+        name = "Contact"
+        URL = "#contact"
+        weight = 4
+
+
+  [languages.es]
+    disabled = false
+    languageCode = 'es'
+    languageDirection = 'ltr'
+    languageName = 'Español'
+    title = ''
+    weight = 0
+      [[languages.es.menus.header]]
+        name = 'Sobre mi'
+        URL = '/es/#about'
+        weight = 2
+      [[languages.es.menus.header]]
+        name = 'Portfolio'
+        URL = '/es/#portfolio'
+        weight = 3
+
+      #  [[languages.es.menus.header]]
+      #  name = "Experiencia"
+      #  URL = "/es/#experience"
+      #  weight = 4
+
+      [[languages.es.menus.header]]
+        name = "Blog"
+        URL = "/es/blog"
+        weight = 5
+
+      [[languages.es.menus.header]]
+        name = "Contacto"
+        URL = "/es/#contact"
+        weight = 6
+
+      [[languages.es.menus.footer]]
+        name = "Sobre mi"
+        URL = "/es/#about"
+        weight = 2
+
+      [[languages.es.menus.footer]]
+        name = "Portfolio"
+        URL = "/es/#portfolio"
+        weight = 3
+
+      [[languages.es.menus.footer]]
+        name = "Contact"
+        URL = "/es/#contact"
+        weight = 4
+
+  [languages.fr]
+    disabled = false
+    languageCode = 'fr'
+    languageDirection = 'ltr'
+    languageName = 'Français'
+    title = ''
+    weight = 0
+
+    [languages.fr.menus]
+      [[languages.fr.menus.header]]
+        name = 'About'
+        URL = '#about'
+        weight = 2
+      [[languages.fr.menus.header]]
+        name = 'Portfolio'
+        URL = '#portfolio'
+        weight = 3
+      #  [[languages.fr.menus.header]]
+      #  name = "Experience"
+      #  URL = "#experience"
+      #  weight = 4
+
+      [[languages.fr.menus.header]]
+        name = "Blog"
+        URL = "/blog"
+        weight = 5
+
+      [[languages.fr.menus.header]]
+        name = "Contact"
+        URL = "#contact"
+        weight = 6
+
+      [[languages.fr.menus.footer]]
+        name = "About"
+        URL = "#about"
+        weight = 2
+
+      [[languages.fr.menus.footer]]
+        name = "Portfolio"
+        URL = "#portfolio"
+        weight = 3
+
+      [[languages.fr.menus.footer]]
+        name = "Contact"
+        URL = "#contact"
+        weight = 4
+  
+  
+
+# Plugins
+[params.plugins]
+
+  # CSS Plugins
+  [[params.plugins.css]]
+  URL = "css/custom.css"
+  [[params.plugins.css]]
+  URL = "css/adritian-icons.css"
+  
+  # JS Plugins
+  [[params.plugins.js]]
+  URL = "js/rad-animations.js"
+  [[params.plugins.js]]
+  URL = "js/sticky-header.js"
+  [[params.plugins.js]]
+  URL = "js/library/fontfaceobserver.js"
+
+  # SCSS Plugins
+  [[params.plugins.scss]]
+  URL = "scss/adritian.scss"
+
+
+# theme/color style 
+[params.colorTheme]
+
+## the following configuration would disable automatic theme selection
+#  [params.colorTheme.auto]
+#    disable = true
+#  [params.colorTheme.forced]
+#    theme = "dark"
+
+## the following parameter will disable theme override in the footer
+#  [params.colorTheme.selector.disable]
+#  footer = true
+
+
+## by default we allow override AND automatic selection
+
+[params.blog]
+layout = "default" # options: default, sidebar
+sidebarWidth = "25" # percentage width of the sidebar
+showCategories = true
+showRecentPosts = true
+recentPostCount = 5
+listStyle = "summary" # options: simple, summary


### PR DESCRIPTION
Fix for the issue https://github.com/zetxek/adritian-free-hugo-theme/issues/177.
The root cause is that with the `hugo modules` installation, some configuration files are missing.

This is being looked into in https://github.com/zetxek/adritian-free-hugo-theme/pull/173 (another PR might follow anyway).

For your repo @Luosua, this PR should do :) 

```
➜  Luosua.github.io git:(main) ✗ hugo serve
Watching for changes in /Users/adrianmorenopena/tmp/Luosua.github.io/{archetypes,data}
Watching for config changes in /Users/adrianmorenopena/tmp/Luosua.github.io/hugo.toml, /Users/adrianmorenopena/tmp/Luosua.github.io/go.mod
Start building sites …
hugo v0.142.0+extended+withdeploy darwin/arm64 BuildDate=2025-01-22T12:20:52Z VendorInfo=brew


                   | EN | ES | FR
-------------------+----+----+-----
  Pages            |  9 |  8 |  8
  Paginator pages  |  0 |  0 |  0
  Non-page files   |  0 |  0 |  0
  Static files     | 83 | 83 | 83
  Processed images |  4 |  0 |  0
  Aliases          |  1 |  0 |  0
  Cleaned          |  0 |  0 |  0

Built in 850 ms
Environment: "development"
Serving pages from disk
Running in Fast Render Mode. For full rebuilds on change: hugo server --disableFastRender
Web Server is available at http://localhost:1313/ (bind address 127.0.0.1)
Press Ctrl+C to stop

Change of config file detected, rebuilding site (#1).
2025-01-28 19:20:27.410 +0100
Web Server is available at http://localhost:1313/ (bind address 127.0.0.1)
Rebuilt in 510 ms
```