### PR TITLE
Remove nav-item class

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -50,7 +50,7 @@
 
             {{- if hugo.IsMultilingual }}
             {{ .Scratch.Set "selectorPlacement" "header" }}
-            <li class="nav-item dropdown">
+            <li class="dropdown">
             {{ partial "selector-language.html" . }}
             </li>
             {{- end }}

--- a/layouts/partials/selector-language.html
+++ b/layouts/partials/selector-language.html
@@ -1,7 +1,7 @@
 {{/* indicates where the partial is placed
  so far the placement can either be header or footer */}}
  {{- $placement := .Scratch.Get "selectorPlacement" }}
-<div id='{{ $placement }}-language-selector' class='language-selector nav-item dropdown dropup {{ if eq $placement "mobile-header" }}nav-link{{ end }}'>
+<div id='{{ $placement }}-language-selector' class='language-selector dropdown {{ if eq $placement "mobile-header" }}nav-link{{ end }}'>
     {{ range .Site.Languages }}
     {{ if eq . $.Site.Language }}
     <button


### PR DESCRIPTION
Workaround for https://github.com/zetxek/adritian-free-hugo-theme/issues/206 until a fix is applied to the theme.

Basically, the class `nav-item` was preventing the menu from rendering. It does now:

https://github.com/user-attachments/assets/0007baa7-8b4d-491c-bcb0-85c0f3363acb

