### PR TITLE
Correct path for static image

### DIFF
--- a/layouts/partials/selector-language.html
+++ b/layouts/partials/selector-language.html
@@ -16,7 +16,7 @@
       aria-label='{{ i18n "language" }}'
     >
     <img
-  src="/portfolio/img/language.png"
+  src="{{ "img/language.png" | absURL }}"
   alt="Language icon"
   width="20"
   height="20"

--- a/layouts/partials/selector-language.html
+++ b/layouts/partials/selector-language.html
@@ -16,7 +16,7 @@
       aria-label='{{ i18n "language" }}'
     >
     <img
-  src="/img/language.png"
+  src="/portfolio/img/language.png"
   alt="Language icon"
   width="20"
   height="20"


### PR DESCRIPTION
As you have `/portfolio` in your baseURL, you need to add the folder to the URL too :) 

https://github.com/Luosua/portfolio/blob/main/hugo.toml#L1

Initially I did it by just hardcoding `/portfolio` before the image URL; but you can use Hugo's functions to generate it correctly (ie: if you edit the path later on).