### PR TITLE
Create override for smooth-scroll-init.js

### DIFF
--- a/static/js/smooth-scroll-init.js
+++ b/static/js/smooth-scroll-init.js
@@ -1,0 +1,2 @@
+// just disabling the smooth scroll
+// see https://github.com/zetxek/adritian-free-hugo-theme/issues/212


### PR DESCRIPTION
To disable smooth scroll. Solves https://github.com/zetxek/adritian-free-hugo-theme/issues/212